### PR TITLE
Issue #3163 of the CORES Mobile project: Fork and patch the cordova-plugin-fingerprint-aio plugin.

### DIFF
--- a/src/android/BiometricActivity.java
+++ b/src/android/BiometricActivity.java
@@ -62,8 +62,16 @@ public class BiometricActivity extends AppCompatActivity {
           case LOAD_SECRET:
             authenticateToDecrypt();
             return;
+          case DISMISS:
+              dismiss();
+              return;
         }
         throw new CryptoException(PluginError.BIOMETRIC_ARGS_PARSING_FAILED);
+    }
+
+    public void dismiss(){
+        mBiometricPrompt.cancelAuthentication();
+        finishWithSuccess();
     }
 
     private void authenticateToEncrypt(boolean invalidateOnEnrollment) throws CryptoException {

--- a/src/android/BiometricActivityType.java
+++ b/src/android/BiometricActivityType.java
@@ -4,6 +4,7 @@ public enum BiometricActivityType {
     JUST_AUTHENTICATE(1),
     REGISTER_SECRET(2),
     LOAD_SECRET(3);
+    DISMISS(4);
 
     private int value;
 

--- a/src/android/BiometricActivityType.java
+++ b/src/android/BiometricActivityType.java
@@ -3,7 +3,7 @@ package de.niklasmerz.cordova.biometric;
 public enum BiometricActivityType {
     JUST_AUTHENTICATE(1),
     REGISTER_SECRET(2),
-    LOAD_SECRET(3);
+    LOAD_SECRET(3),
     DISMISS(4);
 
     private int value;

--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -57,8 +57,15 @@ public class Fingerprint extends CordovaPlugin {
             executeIsAvailable();
             return true;
 
+         } else if ("dismiss".equals(action)){
+            dismiss(args);
+            return true;
         }
         return false;
+    }
+
+    private  void dismiss(JSONArray args){
+        this.runBiometricActivity(args, BiometricActivityType.DISMISS);
     }
 
     private void executeIsAvailable() {

--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -13,6 +13,8 @@ enum PluginError:Int {
     case BIOMETRIC_SECRET_NOT_FOUND = -113
 }
 
+var authenticationContext = LAContext();
+
 @objc(Fingerprint) class Fingerprint : CDVPlugin {
 
     struct ErrorCodes {
@@ -22,7 +24,7 @@ enum PluginError:Int {
 
     @objc(isAvailable:)
     func isAvailable(_ command: CDVInvokedUrlCommand){
-        let authenticationContext = LAContext();
+        
         var biometryType = "finger";
         var errorResponse: [AnyHashable: Any] = [
             "code": 0,
@@ -80,7 +82,7 @@ enum PluginError:Int {
     }
 
     func justAuthenticate(_ command: CDVInvokedUrlCommand) {
-        let authenticationContext = LAContext();
+        
         let errorResponse: [AnyHashable: Any] = [
             "message": "Something went wrong"
         ];
@@ -137,6 +139,7 @@ enum PluginError:Int {
                 self.commandDelegate.send(pluginResult, callbackId:command.callbackId);
             }
         );
+        
     }
 
     func saveSecret(_ secretStr: String, command: CDVInvokedUrlCommand) {
@@ -184,7 +187,7 @@ enum PluginError:Int {
     func authenticate(_ command: CDVInvokedUrlCommand){
         justAuthenticate(command)
     }
-
+    
     @objc(dismiss:)
     func dismiss(_ command: CDVInvokedUrlCommand){
         authenticationContext.invalidate();

--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -185,6 +185,13 @@ enum PluginError:Int {
         justAuthenticate(command)
     }
 
+    @objc(dismiss:)
+    func dismiss(_ command: CDVInvokedUrlCommand){
+        authenticationContext.invalidate();
+        var pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: "Success");
+        self.commandDelegate.send(pluginResult, callbackId:command.callbackId)
+    }
+
     @objc(registerBiometricSecret:)
     func registerBiometricSecret(_ command: CDVInvokedUrlCommand){
         let data  = command.arguments[0] as AnyObject?;

--- a/www/Fingerprint.js
+++ b/www/Fingerprint.js
@@ -64,4 +64,15 @@ Fingerprint.prototype.loadBiometricSecret = function (params, successCallback, e
   );
 };
 
+Fingerprint.prototype.dismiss = function(successCallback, errorCallback, optionalParams){
+  cordova.exec(
+    successCallback,
+    errorCallback,
+    "Fingerprint",
+    "dismiss",
+    [optionalParams]
+  );
+};
+
+
 module.exports = new Fingerprint();


### PR DESCRIPTION
<!-- Thank you for contributing -->

# Description
This PR adds the following change:
- Issue [#3163](https://github.com/TransformativeMed/cores-mobile/issues/3163) of CORES Mobile project (T4M repo):
     - Added the `dismiss` method to remove the biometric authentication popup displayed by the OS (Android/iOS) without require the user interaction.  

# How did you test your changes?
These changes were tested using a physical device and running the CORES Mobile app.

- Android phone: Pixel a6 with 13 version installed.
- iPhone: XR with 16.5.1 version installed.

# Screenshots.
In the next videos, the `dismiss` method is invoked to cancel the authentication dialog that was automatically displayed by the app and redirect the user to a different page:

- Android (the dismiss method will close the fingerprint auth popup):

https://github.com/TransformativeMed/cordova-plugin-fingerprint-aio/assets/12654157/d77a6795-189c-4ff1-b084-2eb32ce90ffc

- iOS (the dismiss method will cancel the face recognition auth popup):

https://github.com/TransformativeMed/cordova-plugin-fingerprint-aio/assets/12654157/7f7976f6-0531-4005-aacd-332c28118d47


